### PR TITLE
add generic Exception

### DIFF
--- a/acloud/_shared.py
+++ b/acloud/_shared.py
@@ -499,6 +499,8 @@ class CloudGuruLectureLectureAssets(object):
                 self._fsize = int(requests.get(self.url, stream=True, headers={'User-Agent': HEADERS.get('User-Agent')}).headers[cl])
             except (conn_error, http_error) as e:
                 self._fsize = 0
+            except Exception as e:
+                self._fsize = 0
         return self._fsize
 
     def download(self, filepath="", quiet=False, callback=lambda *x: None):


### PR DESCRIPTION
In some courses I get an unvalid exception with KeyError: 'content-length'.
With this general exception in any exception cases set _fsize to 0.