### PR TITLE
Updated regexp to match a token as a single string

### DIFF
--- a/acloud/_extract.py
+++ b/acloud/_extract.py
@@ -70,7 +70,7 @@ class CloudGuru(ProgressBar):
     def _extract_cookie_string(self, raw_cookies):
         try:
             mobj = re.search(
-                r"(?is)(Authorization:\s*Bearer\s*(?P<access_token>(.+?)))(\"\s|\s)",
+                r"(?is)(Authorization:\s*Bearer\s*(?P<access_token>(.+?)))($|\s|\"|\')",
                 raw_cookies,
             )
             if not mobj:


### PR DESCRIPTION
Use case: Dev Tools / Inspect -> Network -> graphql -> Request Headers -> authorization
(double-click to copy and paste to the headers file)